### PR TITLE
Add tray utility and MAPI stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # MailJump
-MAPI helper app for New Outlook
+
+MailJump is a simple helper application that provides a minimal MAPI interface for Microsoft Word or other applications that expect a MAPI email client. The tray application receives simplified MAPI requests over a named pipe and invokes **New Outlook** using the `mailto:` protocol to draft the message.
+
+This repository contains two components:
+
+* **MailJumpTray** – a Windows Forms tray application that waits for MAPI requests on a named pipe and launches New Outlook.
+* **MAPIStub** – a minimal `MAPI32.dll` replacement exporting `MAPISendMail`. It serialises the request and forwards it to the tray application through the named pipe.
+
+The stub only implements the features required for Word's "Send to Mail Recipient" command and is not a full MAPI implementation.
+
+## Building
+
+1. **MailJumpTray** requires the .NET 6 SDK or later. Build the project with `dotnet build` targeting `x64`.
+2. **MAPIStub** can be built with any 64-bit Visual Studio toolchain using the provided `MAPIStub.def` to export `MAPISendMail`.
+
+After building, place `MAPI32.dll` from the `MAPIStub` project somewhere in your `PATH` or alongside Word so that it is loaded when a MAPI call is made. Run `MailJumpTray.exe` to start the tray application before using Word's email features.
+
+This project is a basic proof of concept and may need additional work to handle attachments or multiple recipients.

--- a/src/MAPIStub/MAPIStub.cpp
+++ b/src/MAPIStub/MAPIStub.cpp
@@ -1,0 +1,27 @@
+#include <windows.h>
+#include <mapi.h>
+#include <string>
+#include <fstream>
+#include <sstream>
+
+extern "C" ULONG FAR PASCAL MAPISendMail(LHANDLE lhSession, ULONG ulUIParam,
+    lpMapiMessage lpMessage, FLAGS flFlags, ULONG ulReserved)
+{
+    std::ostringstream oss;
+    if (lpMessage && lpMessage->lpszSubject)
+        oss << "{\"subject\":\"" << lpMessage->lpszSubject << "\",";
+    if (lpMessage && lpMessage->lpszNoteText)
+        oss << "\"body\":\"" << lpMessage->lpszNoteText << "\",";
+    if (lpMessage && lpMessage->lpRecips && lpMessage->nRecipCount > 0)
+        oss << "\"to\":\"" << lpMessage->lpRecips[0].lpszAddress << "\",";
+    oss << "\"attachment\":null}";
+    std::string json = oss.str();
+    HANDLE hPipe = CreateFileA(R"\\.\pipe\MailJumpPipe", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    if (hPipe != INVALID_HANDLE_VALUE)
+    {
+        DWORD written;
+        WriteFile(hPipe, json.c_str(), (DWORD)json.size(), &written, NULL);
+        CloseHandle(hPipe);
+    }
+    return SUCCESS_SUCCESS;
+}

--- a/src/MAPIStub/MAPIStub.def
+++ b/src/MAPIStub/MAPIStub.def
@@ -1,0 +1,3 @@
+LIBRARY MAPIStub
+EXPORTS
+    MAPISendMail

--- a/src/MailJumpTray/MailJumpTray.csproj
+++ b/src/MailJumpTray/MailJumpTray.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/MailJumpTray/Program.cs
+++ b/src/MailJumpTray/Program.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO.Pipes;
+using System.Diagnostics;
+using System.Windows.Forms;
+
+namespace MailJumpTray
+{
+    static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            using var notifier = new TrayNotifier();
+            Application.Run();
+        }
+    }
+
+    public class TrayNotifier : IDisposable
+    {
+        private readonly NotifyIcon _icon;
+        private readonly NamedPipeServerStream _pipe;
+        public TrayNotifier()
+        {
+            _icon = new NotifyIcon
+            {
+                Text = "MailJump",
+                Icon = SystemIcons.Application,
+                Visible = true,
+                ContextMenuStrip = new ContextMenuStrip()
+            };
+            _icon.ContextMenuStrip.Items.Add("Exit", null, (s, e) => Application.Exit());
+            _pipe = new NamedPipeServerStream("MailJumpPipe", PipeDirection.In);
+            _ = WaitForMessageAsync();
+        }
+
+        private async Task WaitForMessageAsync()
+        {
+            while (true)
+            {
+                await _pipe.WaitForConnectionAsync();
+                using var reader = new StreamReader(_pipe);
+                var message = await reader.ReadToEndAsync();
+                HandleMAPIMessage(message);
+                _pipe.Disconnect();
+            }
+        }
+
+        private void HandleMAPIMessage(string message)
+        {
+            // message expected in JSON: { "to": "...", "subject": "...", "body": "...", "attachment": "..." }
+            try
+            {
+                var mapi = System.Text.Json.JsonSerializer.Deserialize<MAPIMessage>(message);
+                var args = $"mailto:{mapi?.To}?subject={Uri.EscapeDataString(mapi?.Subject ?? string.Empty)}&body={Uri.EscapeDataString(mapi?.Body ?? string.Empty)}";
+                Process.Start(new ProcessStartInfo(args) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error processing MAPI message: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            _icon.Visible = false;
+            _icon.Dispose();
+            _pipe.Dispose();
+        }
+    }
+
+    public record MAPIMessage(string To, string Subject, string Body, string? Attachment);
+}


### PR DESCRIPTION
## Summary
- add simple Windows Forms tray app to launch New Outlook via mailto
- add minimal MAPI32.dll stub that forwards MAPISendMail to the tray
- update README with build instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c790d5c848321ba5cb05cce02e1b0