### PR TITLE
Fix Task namespace error

### DIFF
--- a/src/MailJumpTray/Program.cs
+++ b/src/MailJumpTray/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO.Pipes;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using Outlook = Microsoft.Office.Interop.Outlook;


### PR DESCRIPTION
## Summary
- add missing `System.Threading.Tasks` using so `Task` resolves

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c81bf64288321bfbaf751b4e560ff