### PR TITLE
Fix missing namespaces

### DIFF
--- a/src/MailJumpTray/Program.cs
+++ b/src/MailJumpTray/Program.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using System.Drawing; // for SystemIcons
+using System.IO;      // for StreamReader
 using Outlook = Microsoft.Office.Interop.Outlook;
 
 namespace MailJumpTray


### PR DESCRIPTION
## Summary
- add missing namespaces for StreamReader and SystemIcons

## Testing
- `dotnet build src/MailJumpTray/MailJumpTray.csproj -c Release -r win-x64` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c862f30688321b5919d4bc510ae90