### PR TITLE
Add NSIS installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ cd scripts
 
 The installer also places `uninstall.ps1` in the install directory so you can remove
 MailJump by running that script later.
+
+For distributing MailJump as a single executable installer you can build the
+NSIS package located in the `installer` folder. Install the NSIS toolset and
+run `makensis` to generate `MailJumpInstaller.exe`:
+
+```bash
+cd installer
+makensis MailJumpInstaller.nsi
+```
+
+The resulting `MailJumpInstaller.exe` installs MailJump to
+`C:\Program Files\MailJump` and registers it as the default MAPI client.

--- a/installer/MailJumpInstaller.nsi
+++ b/installer/MailJumpInstaller.nsi
@@ -1,0 +1,38 @@
+!include "MUI2.nsh"
+
+Name "MailJump"
+OutFile "MailJumpInstaller.exe"
+InstallDir "$PROGRAMFILES\MailJump"
+RequestExecutionLevel admin
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File "../src/MailJumpTray/bin/Release/net9.0-windows/win-x64/publish/MailJumpTray.exe"
+    File "../src/MAPIStub/MAPI32.dll"
+
+    WriteRegStr HKCU "Software\Clients\Mail" "" "MailJump"
+    WriteRegStr HKCU "Software\Clients\Mail\MailJump" "DLLPath" "$INSTDIR\MAPI32.dll"
+    WriteRegStr HKCU "Software\Clients\Mail\MailJump" "ApplicationName" "MailJump"
+
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump" "DisplayName" "MailJump"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump" "DisplayIcon" "$INSTDIR\MailJumpTray.exe"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump" "UninstallString" "$INSTDIR\Uninstall.exe"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump" "InstallLocation" "$INSTDIR"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump" "Publisher" "MailJump Project"
+
+    WriteUninstaller "$INSTDIR\Uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+    Delete "$INSTDIR\MailJumpTray.exe"
+    Delete "$INSTDIR\MAPI32.dll"
+    Delete "$INSTDIR\Uninstall.exe"
+    RMDir "$INSTDIR"
+
+    ReadRegStr $0 HKCU "Software\Clients\Mail" ""
+    StrCmp $0 "MailJump" 0 +2
+        DeleteRegValue HKCU "Software\Clients\Mail" ""
+    DeleteRegKey HKCU "Software\Clients\Mail\MailJump"
+
+    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\MailJump"
+SectionEnd

--- a/src/MAPIStub/MAPIStub.cpp
+++ b/src/MAPIStub/MAPIStub.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <sstream>
 
-extern "C" ULONG FAR PASCAL MAPISendMail(LHANDLE lhSession, ULONG ulUIParam,
+extern "C" ULONG FAR PASCAL MAPISendMail(LHANDLE lhSession, ULONG_PTR ulUIParam,
     lpMapiMessage lpMessage, FLAGS flFlags, ULONG ulReserved)
 {
     std::ostringstream oss;
@@ -36,7 +36,7 @@ extern "C" ULONG FAR PASCAL MAPISendMail(LHANDLE lhSession, ULONG ulUIParam,
     }
     oss << "]}";
     std::string json = oss.str();
-    HANDLE hPipe = CreateFileA(R"\\.\pipe\MailJumpPipe", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    HANDLE hPipe = CreateFileA(R"(\\.\pipe\MailJumpPipe)", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
     if (hPipe != INVALID_HANDLE_VALUE)
     {
         DWORD written;


### PR DESCRIPTION
## Summary
- add NSIS installer script for building an executable installer
- document how to build the installer in README
- fix MAPIStub raw string for Windows pipe and update prototype

## Testing
- `dotnet build -c Release -p:EnableWindowsTargeting=true`
- `dotnet publish -c Release -r win-x64 -p:EnableWindowsTargeting=true -p:PublishSingleFile=false`
- `x86_64-w64-mingw32-g++ -std=c++11 -shared -o MAPI32.dll MAPIStub.cpp -static -lws2_32 -O2 -Wl,--output-def,MAPIStub.def`
- `makensis MailJumpInstaller.nsi`

------
https://chatgpt.com/codex/tasks/task_e_685c9407c8408321840409a2a30df8c8