### PR TITLE
Use custom icons

### DIFF
--- a/installer/MailJumpInstaller.nsi
+++ b/installer/MailJumpInstaller.nsi
@@ -2,6 +2,8 @@
 
 Name "MailJump"
 OutFile "MailJumpInstaller.exe"
+Icon "../src/MailJumpTray/icons/mailjump-128.ico"
+UninstallIcon "../src/MailJumpTray/icons/mailjump-128.ico"
 InstallDir "$PROGRAMFILES\MailJump"
 RequestExecutionLevel admin
 

--- a/src/MailJumpTray/MailJumpTray.csproj
+++ b/src/MailJumpTray/MailJumpTray.csproj
@@ -4,8 +4,14 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
+    <ApplicationIcon>icons\mailjump-64.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Office.Interop.Outlook" Version="15.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="icons\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/MailJumpTray/Program.cs
+++ b/src/MailJumpTray/Program.cs
@@ -29,10 +29,11 @@ namespace MailJumpTray
         private readonly NamedPipeServerStream _pipe;
         public TrayNotifier()
         {
+            var iconPath = Path.Combine(AppContext.BaseDirectory, "icons", "mailjump-64.ico");
             _icon = new NotifyIcon
             {
                 Text = "MailJump",
-                Icon = SystemIcons.Application,
+                Icon = File.Exists(iconPath) ? new Icon(iconPath) : SystemIcons.Application,
                 Visible = true,
                 ContextMenuStrip = new ContextMenuStrip()
             };


### PR DESCRIPTION
## Summary
- set tray icon at runtime using icon file
- include icons as content and set application icon
- give installer a custom icon

## Testing
- `dotnet build src/MailJumpTray/MailJumpTray.csproj -c Release -p:EnableWindowsTargeting=true`
- `makensis installer/MailJumpInstaller.nsi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca24c033c8321818becd380be6ccd