### PR TITLE
Fix quoting in build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -52,7 +52,7 @@ if (-not (Test-Path $vcvars)) {
 }
 $buildCmd = 'cl.exe /nologo /LD MAPIStub.cpp /FeMAPI32.dll /link /DEF:MAPIStub.def'
 Push-Location 'src/MAPIStub'
-$cmdString = "call `\"$vcvars`\" && $buildCmd"
+$cmdString = "call `"$vcvars`" && $buildCmd"
 cmd /c $cmdString
 Pop-Location
 


### PR DESCRIPTION
## Summary
- fix quoting when building MAPIStub

## Testing
- `pwsh -NoProfile -Command ". ./build.ps1"` *(fails: Windows Principal functionality is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_685db9bdefec83218ac004682463210a